### PR TITLE
Issue #2214355. Remove Drupal.org packaging info from .info file.

### DIFF
--- a/shareaholic.info
+++ b/shareaholic.info
@@ -7,17 +7,3 @@ files[] = tests/shareaholic.test
 files[] = tests/utilities.test
 files[] = tests/admin.test
 files[] = tests/public.test
-
-; Information added by drupal.org packaging script on 2011-05-30
-version = "7.x-2.0"
-core = "7.x"
-project = "shareaholic"
-datestamp = "1306745218"
-
-
-; Information added by drupal.org packaging script on 2012-06-29
-version = "7.x-3.4"
-core = "7.x"
-project = "shareaholic"
-datestamp = "1340972236"
-


### PR DESCRIPTION
https://drupal.org/node/2214355
