### PR TITLE
Hn fix content node flush

### DIFF
--- a/includes/node.php
+++ b/includes/node.php
@@ -31,7 +31,6 @@
   function shareaholic_node_update($node) {
     ShareaholicContentSettings::update($node);
     ShareaholicContentManager::single_page_worker($node);
-    ShareaholicUtilities::clear_fb_opengraph($node);
   }
 
 
@@ -57,7 +56,6 @@
   function shareaholic_node_insert($node) {
     ShareaholicContentSettings::insert($node);
     ShareaholicContentManager::single_page_worker($node);
-    ShareaholicUtilities::clear_fb_opengraph($node);
   }
 
 

--- a/public.php
+++ b/public.php
@@ -410,7 +410,7 @@ DOC;
     set_error_handler(array('ShareaholicPublic', 'custom_error_handler'));
     $debug_mode = isset($_GET['debug']) && $_GET['debug'] === '1';
     $cache_key = 'shr_api_res-' . md5( $_SERVER['QUERY_STRING'] );
-    $result = ShareaholicCache::get($cache_key);
+    $result = FALSE;
     $has_curl_multi = self::has_curl();
 
     if (!$result) {
@@ -444,7 +444,7 @@ DOC;
         }
 
         if (isset($result['data']) && !$debug_mode) {
-          ShareaholicCache::set($cache_key, $result, SHARE_COUNTS_CHECK_CACHE_LENGTH);
+
         }
       }
     }

--- a/public.php
+++ b/public.php
@@ -410,7 +410,7 @@ DOC;
     set_error_handler(array('ShareaholicPublic', 'custom_error_handler'));
     $debug_mode = isset($_GET['debug']) && $_GET['debug'] === '1';
     $cache_key = 'shr_api_res-' . md5( $_SERVER['QUERY_STRING'] );
-    $result = FALSE;
+    $result = ShareaholicCache::get($cache_key);
     $has_curl_multi = self::has_curl();
 
     if (!$result) {
@@ -444,7 +444,7 @@ DOC;
         }
 
         if (isset($result['data']) && !$debug_mode) {
-
+          ShareaholicCache::set($cache_key, $result, SHARE_COUNTS_CHECK_CACHE_LENGTH);
         }
       }
     }

--- a/utilities.php
+++ b/utilities.php
@@ -721,7 +721,7 @@ class ShareaholicUtilities {
     $share_counts_api_url = url('shareaholic/api/share_counts/v1', array('absolute' => TRUE)) . '?action=shareaholic_share_counts_api&url=https%3A%2F%2Fwww.google.com%2F&services[]=' . $param_string;
     $cache_key = 'share_counts_api_connectivity_check';
     // fetch cached response if it exists or has not expired
-    $response = FALSE;
+    $response = ShareaholicCache::get($cache_key);
 
     if (!$response) {
       $response = ShareaholicHttp::send($share_counts_api_url, array('method' => 'GET'), true);
@@ -735,7 +735,7 @@ class ShareaholicUtilities {
     }
 
     if ($response_status == 'SUCCESS') {
-
+      ShareaholicCache::set($cache_key, $response, SHARE_COUNTS_CHECK_CACHE_LENGTH);
     }
 
     self::update_options(array('share_counts_connect_check' => $response_status));

--- a/utilities.php
+++ b/utilities.php
@@ -721,7 +721,7 @@ class ShareaholicUtilities {
     $share_counts_api_url = url('shareaholic/api/share_counts/v1', array('absolute' => TRUE)) . '?action=shareaholic_share_counts_api&url=https%3A%2F%2Fwww.google.com%2F&services[]=' . $param_string;
     $cache_key = 'share_counts_api_connectivity_check';
     // fetch cached response if it exists or has not expired
-    $response = ShareaholicCache::get($cache_key);
+    $response = FALSE;
 
     if (!$response) {
       $response = ShareaholicHttp::send($share_counts_api_url, array('method' => 'GET'), true);
@@ -735,7 +735,7 @@ class ShareaholicUtilities {
     }
 
     if ($response_status == 'SUCCESS') {
-      ShareaholicCache::set($cache_key, $response, SHARE_COUNTS_CHECK_CACHE_LENGTH);
+
     }
 
     self::update_options(array('share_counts_connect_check' => $response_status));


### PR DESCRIPTION
There is a bug (which I cannot reproduce) that a few drupal publishers are experiencing where any new content they create will render a page but without the actual content. After they flush Drupal cache they are able to see the content again.

After debugging this with a couple of publishers, I have found that this is the cause. The original intent for clearing fb open graph data on content create/update was to prevent 404 messages when trying to share via facebook. This was caused by FB Share counts being called on a draft or non-public page.

We will not need this call anymore because FB Share counts will only be called on public pages which will prevent FB sharing from presenting 404 errors.